### PR TITLE
💡 Implement simple caching with Redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "nocache": "^4.0.0",
     "octokit": "^2.0.14",
     "openapi-backend": "^5.9.1",
+    "redis": "^4.6.7",
     "swagger-ui-express": "^4.6.2"
   },
   "nodemonConfig": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,43 +7,52 @@ import swaggerUi from "swagger-ui-express";
 import { routes } from "./routes";
 import { SetupLogging } from "./logging";
 import nocache from "nocache";
+import { createClient } from 'redis';
 
-SetupLogging();
+export const redisClient = createClient();
+export type CacheClient = typeof redisClient;
+Do();
 
-const app = express();
-app.use(nocache());
+async function Do() {
+  await redisClient.connect();
 
-const port = process.env.PORT;
+  SetupLogging();
 
-// TODO: fix/determine why OpenAPIBackend is having issues loading files on its own...
-const doc = yaml.load(fs.readFileSync(path.resolve(__dirname, 'openapi.yaml'), 'utf8'));
-
-const castDoc = doc as Document;
-
-const api = new OpenAPIBackend({ definition: castDoc });
-
-api.register({
-  ...routes,
-  validationFail: (c, _, res) => res.status(400).json({ err: c.validation.errors }),
-  notFound: (c, _, res) => res.status(404).json({ err: 'not found' }),
-});
-
-app.use(express.json());
-
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(doc as swaggerUi.JsonObject));
-
-app.use((req: any, res: any) => {
-    api.handleRequest(req, req, res).catch((reason:any) => {
-      console.log(reason);      
-
-      res.status(500).json({ err: 'An internal error occurred :( Please ask the maintainers of the running application to check the logs.' })
-    })
-});
-
-console.log({
-  HostPort: port,
-  ForwardingGitHubRequestsTo: process.env.GITHUB_PROXY ?? "Not forwarding",
-  ForwardingGroupRequestsTo: process.env.SOURCE_PROXY ?? "Not forwarding"
-})
-
-app.listen(port);
+  const app = express();
+  app.use(nocache());
+  
+  const port = process.env.PORT;
+  
+  // TODO: fix/determine why OpenAPIBackend is having issues loading files on its own...
+  const doc = yaml.load(fs.readFileSync(path.resolve(__dirname, 'openapi.yaml'), 'utf8'));
+  
+  const castDoc = doc as Document;
+  
+  const api = new OpenAPIBackend({ definition: castDoc });
+  
+  api.register({
+    ...routes,
+    validationFail: (c, _, res) => res.status(400).json({ err: c.validation.errors }),
+    notFound: (c, _, res) => res.status(404).json({ err: 'not found' }),
+  });
+  
+  app.use(express.json());
+  
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(doc as swaggerUi.JsonObject));
+  
+  app.use((req: any, res: any) => {
+      api.handleRequest(req, req, res).catch((reason:any) => {
+        console.log(reason);      
+  
+        res.status(500).json({ err: 'An internal error occurred :( Please ask the maintainers of the running application to check the logs.' })
+      })
+  });
+  
+  console.log({
+    HostPort: port,
+    ForwardingGitHubRequestsTo: process.env.GITHUB_PROXY ?? "Not forwarding",
+    ForwardingGroupRequestsTo: process.env.SOURCE_PROXY ?? "Not forwarding"
+  })
+  
+  app.listen(port);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,10 @@ import nocache from "nocache";
 import { createClient } from 'redis';
 import { Config } from "./config";
 
-export const redisClient = createClient();
+export const redisClient = createClient({
+  url: `redis://${process.env.APP_OPTIONS_RedisHost}`
+});
+
 export type CacheClient = typeof redisClient;
 Do();
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,51 +8,54 @@ import { routes } from "./routes";
 import { SetupLogging } from "./logging";
 import nocache from "nocache";
 import { createClient } from 'redis';
+import { Config } from "./config";
 
 export const redisClient = createClient();
 export type CacheClient = typeof redisClient;
 Do();
 
 async function Do() {
-  await redisClient.connect();
+  if (Config().AppOptions.RedisHost) {
+    await redisClient.connect();
+  }
 
   SetupLogging();
 
   const app = express();
   app.use(nocache());
-  
+
   const port = process.env.PORT;
-  
+
   // TODO: fix/determine why OpenAPIBackend is having issues loading files on its own...
   const doc = yaml.load(fs.readFileSync(path.resolve(__dirname, 'openapi.yaml'), 'utf8'));
-  
+
   const castDoc = doc as Document;
-  
+
   const api = new OpenAPIBackend({ definition: castDoc });
-  
+
   api.register({
     ...routes,
     validationFail: (c, _, res) => res.status(400).json({ err: c.validation.errors }),
     notFound: (c, _, res) => res.status(404).json({ err: 'not found' }),
   });
-  
+
   app.use(express.json());
-  
+
   app.use('/docs', swaggerUi.serve, swaggerUi.setup(doc as swaggerUi.JsonObject));
-  
+
   app.use((req: any, res: any) => {
-      api.handleRequest(req, req, res).catch((reason:any) => {
-        console.log(reason);      
-  
-        res.status(500).json({ err: 'An internal error occurred :( Please ask the maintainers of the running application to check the logs.' })
-      })
+    api.handleRequest(req, req, res).catch((reason: any) => {
+      console.log(reason);
+
+      res.status(500).json({ err: 'An internal error occurred :( Please ask the maintainers of the running application to check the logs.' })
+    })
   });
-  
+
   console.log({
     HostPort: port,
     ForwardingGitHubRequestsTo: process.env.GITHUB_PROXY ?? "Not forwarding",
     ForwardingGroupRequestsTo: process.env.SOURCE_PROXY ?? "Not forwarding"
   })
-  
+
   app.listen(port);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,8 @@ export function Config() {
         },
         AppOptions: {
             AppConfigRepo: process.env.APP_OPTIONS_AppConfigRepo!,
-            AppConfigOrg: process.env.APP_OPTIONS_AppConfigOrg!
+            AppConfigOrg: process.env.APP_OPTIONS_AppConfigOrg!,
+            RedisHost: process.env.APP_OPTIONS_RedisHost
             // GitHubIdAppend: process.env.APP_OPTIONS_GitHubIdAppend!,
             // SecurityManagerTeams: securityManagerTeams
         }

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+
 
 import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
@@ -9,6 +9,9 @@ import yaml from "js-yaml";
 import { throttling } from "@octokit/plugin-throttling";
 import { AsyncReturnType } from "../utility";
 import { Log } from "../logging";
+import { GitHubClientCache } from "./gitHubCache";
+import { redisClient } from "../app";
+
 
 const config = Config();
 
@@ -78,7 +81,7 @@ async function GetOrgClient(installationId: number): Promise<InstalledClient> {
     
     // HACK: gross typing nonsense
     const baseClient = new InstalledGitHubClient(installedOctokit, (orgName?.data?.account as any)?.login);
-    const cachedClient = new GitHubClientCache(baseClient);
+    const cachedClient = new GitHubClientCache(baseClient, redisClient);
     return cachedClient;
 }
 

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -75,10 +75,11 @@ async function GetOrgClient(installationId: number): Promise<InstalledClient> {
         // TODO: throw custom wrapped error...
         throw new Error("Login cannot be null for orgs")
     }
-
-    // TODO: wrap in caching decorator 
+    
     // HACK: gross typing nonsense
-    return new InstalledGitHubClient(installedOctokit, (orgName?.data?.account as any)?.login);
+    const baseClient = new InstalledGitHubClient(installedOctokit, (orgName?.data?.account as any)?.login);
+    const cachedClient = new GitHubClientCache(baseClient);
+    return cachedClient;
 }
 
 function authenticatedClient() {

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -1,4 +1,4 @@
-
+// @ts-nocheck
 
 import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -81,8 +81,13 @@ async function GetOrgClient(installationId: number): Promise<InstalledClient> {
     
     // HACK: gross typing nonsense
     const baseClient = new InstalledGitHubClient(installedOctokit, (orgName?.data?.account as any)?.login);
-    const cachedClient = new GitHubClientCache(baseClient, redisClient);
-    return cachedClient;
+
+    if(Config().AppOptions.RedisHost) {
+        const cachedClient = new GitHubClientCache(baseClient, redisClient);
+        return cachedClient;
+    }        
+
+    return baseClient;
 }
 
 function authenticatedClient() {

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -1,8 +1,5 @@
 import { CacheClient } from "../app";
 import { GitHubTeamId, InstalledClient, OrgConfiguration, Response } from "./gitHubTypes";
-import { createClient } from 'redis';
-
-
 
 export class GitHubClientCache implements InstalledClient {
     client: InstalledClient;

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -1,51 +1,108 @@
+import { CacheClient } from "../app";
 import { GitHubTeamId, InstalledClient, OrgConfiguration, Response } from "./gitHubTypes";
+import { createClient } from 'redis';
+
+
 
 export class GitHubClientCache implements InstalledClient {
     client: InstalledClient;
-    
-    constructor(client: InstalledClient) {
+    cacheClient: CacheClient;
+
+    constructor(client: InstalledClient, cacheClient: CacheClient) {
         this.client = client;
+        this.cacheClient = cacheClient;
     }
 
     GetCurrentOrgName(): string {
         return this.client.GetCurrentOrgName();
     }
+
     GetCurrentRateLimit(): Promise<{ remaining: number; }> {
         return this.client.GetCurrentRateLimit();
     }
+
     AddOrgMember(id: string): Response<unknown> {
         return this.client.AddOrgMember(id);
     }
-    IsUserMember(id: string): Response<boolean> {
-        return this.client.IsUserMember(id);
+
+    async IsUserMember(id: string): Response<boolean> {        
+        const cacheKey = `github-member:${id}-${this.GetCurrentOrgName()}`;
+
+        const result = await this.cacheClient.get(cacheKey);        
+
+        if (result) {
+            return {
+                successful: true,
+                data: Boolean(result)
+            }
+        }        
+
+        const actualResult = await this.client.IsUserMember(id);
+        
+        if (actualResult.successful) {            
+            await this.cacheClient.set(cacheKey, actualResult.data.toString(), {
+                EX: 172800 // Expire every 2 days
+            });            
+        }
+
+        return actualResult;    
     }
+
     GetAllTeams(): Response<GitHubTeamId[]> {
         return this.client.GetAllTeams();
     }
+
     AddTeamMember(team: string, id: string): Response<unknown> {
         return this.client.AddTeamMember(team, id);
     }
+
     CreateTeam(teamName: string, description: string): Response<unknown> {
         return this.client.CreateTeam(teamName, description);
     }
-    DoesUserExist(gitHubId: string): Response<string> {
-        return this.client.DoesUserExist(gitHubId);
+
+    async DoesUserExist(gitHubId: string): Response<string> {
+        const cacheKey = `github-user:${gitHubId}`;
+
+        const result = await this.cacheClient.get(cacheKey);        
+
+        if (result) {
+            return {
+                successful: true,
+                data: result
+            }
+        }        
+
+        const actualResult = await this.client.DoesUserExist(gitHubId);
+
+        if (actualResult.successful) {
+            await this.cacheClient.set(cacheKey, actualResult.data, {
+                EX: 2592000 // Expire every 30 days
+            });
+        }
+
+        return actualResult;
     }
+
     ListCurrentMembersOfGitHubTeam(team: string): Response<string[]> {
         return this.client.ListCurrentMembersOfGitHubTeam(team);
     }
+
     RemoveTeamMemberAsync(team: string, user: string): Response<unknown> {
         return this.client.RemoveTeamMemberAsync(team, user);
     }
+
     UpdateTeamDetails(team: string, description: string): Response<unknown> {
         return this.client.UpdateTeamDetails(team, description);
     }
+
     AddSecurityManagerTeam(team: string): Promise<unknown> {
         return this.client.AddSecurityManagerTeam(team);
     }
+
     GetConfigurationForInstallation(): Response<OrgConfiguration> {
         return this.client.GetConfigurationForInstallation();
     }
+
     GetOrgMembers(): Response<string[]> {
         return this.client.GetOrgMembers();
     }

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -1,0 +1,52 @@
+import { GitHubTeamId, InstalledClient, OrgConfiguration, Response } from "./gitHubTypes";
+
+export class GitHubClientCache implements InstalledClient {
+    client: InstalledClient;
+    
+    constructor(client: InstalledClient) {
+        this.client = client;
+    }
+
+    GetCurrentOrgName(): string {
+        return this.client.GetCurrentOrgName();
+    }
+    GetCurrentRateLimit(): Promise<{ remaining: number; }> {
+        return this.client.GetCurrentRateLimit();
+    }
+    AddOrgMember(id: string): Response<unknown> {
+        return this.client.AddOrgMember(id);
+    }
+    IsUserMember(id: string): Response<boolean> {
+        return this.client.IsUserMember(id);
+    }
+    GetAllTeams(): Response<GitHubTeamId[]> {
+        return this.client.GetAllTeams();
+    }
+    AddTeamMember(team: string, id: string): Response<unknown> {
+        return this.client.AddTeamMember(team, id);
+    }
+    CreateTeam(teamName: string, description: string): Response<unknown> {
+        return this.client.CreateTeam(teamName, description);
+    }
+    DoesUserExist(gitHubId: string): Response<string> {
+        return this.client.DoesUserExist(gitHubId);
+    }
+    ListCurrentMembersOfGitHubTeam(team: string): Response<string[]> {
+        return this.client.ListCurrentMembersOfGitHubTeam(team);
+    }
+    RemoveTeamMemberAsync(team: string, user: string): Response<unknown> {
+        return this.client.RemoveTeamMemberAsync(team, user);
+    }
+    UpdateTeamDetails(team: string, description: string): Response<unknown> {
+        return this.client.UpdateTeamDetails(team, description);
+    }
+    AddSecurityManagerTeam(team: string): Promise<unknown> {
+        return this.client.AddSecurityManagerTeam(team);
+    }
+    GetConfigurationForInstallation(): Response<OrgConfiguration> {
+        return this.client.GetConfigurationForInstallation();
+    }
+    GetOrgMembers(): Response<string[]> {
+        return this.client.GetOrgMembers();
+    }
+}


### PR DESCRIPTION
This will be one of my first opinionated stances on caching implementations. As Redis is open source and fairly prevalent, the configuration values for external cache shall be apart of `AppOptions`.

Furthermore, this PR enhances two GitHub calls by wrapping them in a cache call. This will help reduce the amount of calls made to GitHub, increasing performance overall.

Implementation wise, this PR does some bad things to the cleanliness of this code (circular dependencies between modules, etc.). I am saying that this is "okay" for now as an upcoming change will refactor this repo heavily so as to leverage a DI container.