### PR TITLE
Feature: check in-flight invitations

### DIFF
--- a/src/handlers/syncAll.ts
+++ b/src/handlers/syncAll.ts
@@ -5,12 +5,15 @@ import { SyncOrg } from "../services/githubSync";
 import { GitHubClient } from "../services/gitHubTypes";
 import axios from 'axios';
 import { Log } from "../logging";
+import { GetInvitationsClient } from "../services/githubInvitations";
 
 async function syncOrgLocal(installationId: number, client: GitHubClient) {
     const orgClient = await client.GetOrgClient(installationId);
     const appConfig = await client.GetAppConfig();
 
-    return await SyncOrg(orgClient, appConfig)
+    const invitationsClient = GetInvitationsClient(orgClient);
+
+    return await SyncOrg(orgClient, appConfig, invitationsClient)
 }
 
 export async function syncAllHandler(

--- a/src/handlers/syncOrg.ts
+++ b/src/handlers/syncOrg.ts
@@ -5,6 +5,7 @@ import { SyncOrg } from "../services/githubSync";
 import { AsyncReturnType } from "../utility";
 import axios from 'axios';
 import { Log } from "../logging";
+import { GetInvitationsClient } from "../services/githubInvitations";
 
 async function forwardToProxy(installationId: number) {    
     Log(`Forwarding request to '${process.env.GITHUB_PROXY}'`);
@@ -48,8 +49,9 @@ export async function syncOrgHandler(
     for (let i of distinctIds) {
         const orgClient = await client.GetOrgClient(i);
         const appConfig = await client.GetAppConfig();
+        const invitationsClient = GetInvitationsClient(orgClient);
 
-        syncOrgResponses.push(await SyncOrg(orgClient, appConfig));
+        syncOrgResponses.push(await SyncOrg(orgClient, appConfig, invitationsClient));
     }
 
     return res.status(200).json(syncOrgResponses);

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 import { Config } from "../config";
-import { GitHubClient, GitHubId, GitHubTeamId, GitHubTeamName, InstalledClient, Org, OrgConfiguration, OrgRoles, Response } from "./gitHubTypes";
+import { GitHubClient, GitHubId, GitHubTeamId, GitHubTeamName, InstalledClient, Org, OrgConfiguration, OrgInvite, OrgRoles, Response } from "./gitHubTypes";
 import { AppConfig } from "./appConfig";
 import yaml from "js-yaml";
 import { throttling } from "@octokit/plugin-throttling";
@@ -208,6 +208,50 @@ class InstalledGitHubClient implements InstalledClient {
     constructor(gitHubClient: Octokit, orgName: string) {
         this.gitHubClient = gitHubClient;
         this.orgName = orgName;
+    }
+    
+    async CancelOrgInvite(invite: OrgInvite): Response<unknown> {
+        const response = await this.gitHubClient.rest.orgs.cancelInvitation({
+            invitation_id: invite.InviteId,
+            org: this.orgName
+        })
+
+        if(response.status < 200 || response.status > 299) {
+            return {
+                successful: false
+            }
+        }
+
+        return {
+            successful: true,
+            data: null
+        }
+    }
+
+    async GetPendingOrgInvites(): Response<OrgInvite[]> {
+        // const response = await this.gitHubClient.request('GET /orgs/{org}/invitations', {
+        //     org: this.orgName,
+        //     headers: {
+        //       'X-GitHub-Api-Version': '2022-11-28'
+        //     }
+        //   })
+        const response = await this.gitHubClient.paginate(this.gitHubClient.rest.orgs.listPendingInvitations, {
+            org: this.orgName,
+            role: "all",
+            headers: {
+                "x-github-api-version":"2022-11-28"
+            }        
+        })
+
+        return {
+            successful: true,
+            data: (response as any)?.map((d:any) => {
+                return {
+                    InviteId:d.id,
+                    GitHubUser:d.login!                   
+                }
+            }) ?? []
+        }
     }
 
     public async SetOrgRole(id: GitHubId, role: OrgRoles): Response {

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -209,6 +209,29 @@ class InstalledGitHubClient implements InstalledClient {
         this.gitHubClient = gitHubClient;
         this.orgName = orgName;
     }
+
+    async ListPendingInvitesForTeam(teamName: string): Response<OrgInvite[]> {
+        const response = await this.gitHubClient.rest.teams.listPendingInvitationsInOrg({
+            org: this.orgName,
+            team_slug: teamName
+        })
+
+        if(response.status < 200 || response.status > 299) {
+            return {
+                successful: false
+            }
+        }
+
+        return {
+            successful: true,
+            data: response.data.map(i => {
+                return {
+                    GitHubUser: i.login!,
+                    InviteId: i.id!
+                }
+            })
+        }
+    }
     
     async CancelOrgInvite(invite: OrgInvite): Response<unknown> {
         const response = await this.gitHubClient.rest.orgs.cancelInvitation({
@@ -229,12 +252,6 @@ class InstalledGitHubClient implements InstalledClient {
     }
 
     async GetPendingOrgInvites(): Response<OrgInvite[]> {
-        // const response = await this.gitHubClient.request('GET /orgs/{org}/invitations', {
-        //     org: this.orgName,
-        //     headers: {
-        //       'X-GitHub-Api-Version': '2022-11-28'
-        //     }
-        //   })
         const response = await this.gitHubClient.paginate(this.gitHubClient.rest.orgs.listPendingInvitations, {
             org: this.orgName,
             role: "all",

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -1,6 +1,6 @@
 import { CacheClient } from "../app";
 import { ILogger } from "../logging";
-import { GitHubTeamId, InstalledClient, OrgConfiguration, OrgRoles, Response } from "./gitHubTypes";
+import { GitHubTeamId, InstalledClient, OrgConfiguration, OrgInvite, OrgRoles, Response } from "./gitHubTypes";
 
 export class GitHubClientCache implements InstalledClient {
     client: InstalledClient;
@@ -12,6 +12,15 @@ export class GitHubClientCache implements InstalledClient {
         this.cacheClient = cacheClient;
         this.logger = logger;
     }
+    
+    CancelOrgInvite(invite: OrgInvite): Response<unknown> {
+        return this.client.CancelOrgInvite(invite);
+    }
+
+    GetPendingOrgInvites(): Response<OrgInvite[]> {
+        return this.client.GetPendingOrgInvites();
+    }
+
     SetOrgRole(id: string, role: OrgRoles): Response<unknown> {
         return this.client.SetOrgRole(id, role);
     }

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -13,6 +13,10 @@ export class GitHubClientCache implements InstalledClient {
         this.logger = logger;
     }
     
+    ListPendingInvitesForTeam(teamName: string): Response<OrgInvite[]> {
+        return this.client.ListPendingInvitesForTeam(teamName);
+    }
+    
     CancelOrgInvite(invite: OrgInvite): Response<unknown> {
         return this.client.CancelOrgInvite(invite);
     }

--- a/src/services/gitHubTypes.ts
+++ b/src/services/gitHubTypes.ts
@@ -13,6 +13,11 @@ export interface GitHubClient {
 
 export type OrgRoles = "admin" | "member";
 
+export type OrgInvite = {
+    InviteId: number,
+    GitHubUser: string
+}
+
 export interface InstalledClient {
     GetCurrentOrgName(): string
     GetCurrentRateLimit(): Promise<{ remaining: number }>
@@ -29,6 +34,8 @@ export interface InstalledClient {
     GetConfigurationForInstallation(): Response<OrgConfiguration>    
     GetOrgMembers(): Response<GitHubId[]>
     SetOrgRole(id: GitHubId, role: OrgRoles): Response
+    GetPendingOrgInvites():Response<OrgInvite[]>
+    CancelOrgInvite(invite:OrgInvite): Response
 }
 
 

--- a/src/services/gitHubTypes.ts
+++ b/src/services/gitHubTypes.ts
@@ -35,7 +35,8 @@ export interface InstalledClient {
     GetOrgMembers(): Response<GitHubId[]>
     SetOrgRole(id: GitHubId, role: OrgRoles): Response
     GetPendingOrgInvites():Response<OrgInvite[]>
-    CancelOrgInvite(invite:OrgInvite): Response
+    CancelOrgInvite(invite:OrgInvite): Response    
+    ListPendingInvitesForTeam(teamName: GitHubTeamName):Response<OrgInvite[]>
 }
 
 

--- a/src/services/githubInvitations.ts
+++ b/src/services/githubInvitations.ts
@@ -1,0 +1,47 @@
+import { GenericSucceededResponse, InstalledClient, OrgInvite,Response } from "./gitHubTypes";
+
+export interface IGitHubInvitations {
+    ListInvites():Response<OrgInvite[]>
+}
+
+export function GetInvitationsClient(client:InstalledClient) {
+    return new GitHubInvitations(client);
+}
+
+class GitHubInvitations implements IGitHubInvitations {
+    client:InstalledClient;
+
+    constructor(client:InstalledClient) {
+        this.client = client;
+    }
+
+    async ListInvites(): Response<OrgInvite[]> {
+        const allTeams = await this.client.GetAllTeams();
+
+        if(!allTeams.successful) {
+            return {
+                successful: false
+            }
+        }
+    
+        type AsyncReturnType<T extends (...args: any) => Promise<any>> =
+        T extends (...args: any) => Promise<infer R> ? R : any
+    
+        type responseType = AsyncReturnType<typeof this.client.ListPendingInvitesForTeam>
+    
+        const allPendingPromises = allTeams.data.map(t => this.client.ListPendingInvitesForTeam(t.Name));
+    
+        const allPendingInvitesResults = await Promise.allSettled(allPendingPromises);    
+        
+        const allPendingInvites = allPendingInvitesResults
+            .filter(r => r.status == "fulfilled")
+            .map(r => (r as any).value as responseType)
+            .filter(r => r.successful == true && r.data.length > 0)
+            .flatMap(r => (r as GenericSucceededResponse<OrgInvite[]>).data)
+
+        return {
+            successful:true,
+            data:allPendingInvites
+        };
+    }
+}

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -203,6 +203,8 @@ async function syncOrg(installedGitHubClient: InstalledClient, config: AppConfig
         orgOwnersGroup: ""
     }
 
+    await CancelPendingOrgInvites(installedGitHubClient);
+
     const existingTeamsResponse = await installedGitHubClient.GetAllTeams();
     if (!existingTeamsResponse.successful) {
         throw new Error("Unable to get existing teams");
@@ -390,5 +392,24 @@ export async function SyncOrg(installedGitHubClient: InstalledClient, config: Ap
         )); 
 
         return response;
+    }
+}
+
+async function CancelPendingOrgInvites(installedGitHubClient: InstalledClient) {
+    const orgName = installedGitHubClient.GetCurrentOrgName();    
+    const response = await installedGitHubClient.GetPendingOrgInvites();
+
+    if(!response.successful) {
+        return;
+    }
+
+    for(const invite of response.data) {
+        const user = invite.GitHubUser;
+        Log(JSON.stringify({
+            message: `Cancelling invite for ${user} in ${orgName}`,
+            org: orgName,            
+            user: invite.GitHubUser
+        }))
+        await installedGitHubClient.CancelOrgInvite(invite);
     }
 }

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -214,6 +214,8 @@ async function syncOrg(installedGitHubClient: InstalledClient, config: AppConfig
         orgOwnersGroup: ""
     }
 
+    // TODO: add this back once these APIs make sense
+    // and function...
     // await CancelPendingOrgInvites(installedGitHubClient);
 
     const currentInvitesResponse = await invitationsClient.ListInvites();

--- a/src/services/ldapClient.ts
+++ b/src/services/ldapClient.ts
@@ -12,11 +12,12 @@ let client: ldap.Client;
 
 if (!process.env.SOURCE_PROXY) {
     client = ldap.createClient({
-        url: [config.LDAP.Server]
+        url: [config.LDAP.Server]        
     });
 
     client.bind(config.LDAP.User, config.LDAP.Password, (err, result) => {
         if (err) {
+            console.log("Failed to connect to LDAP Server");
             LogError(JSON.stringify(err) as any);
         }
 


### PR DESCRIPTION
Shifting gears since the Cancel Invites API either doesn't work or I just haven't figured it out...

This feature makes the output of sync jobs better by displaying whether a user has an existing Invite or not. This will allow interested parties to more accurately check on the status of their team(s).

----

Context: https://github.com/cloudpups/github-teams-user-sync/issues/3

...more detail to be added to PR.

The list invites endpoint seems to only be returning 404s during testing of this. As such, development of this particular feature will be put on hold until I/we can figure out what is happening with that call 😀