### PR TITLE
Improve error response for add/remove members

### DIFF
--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 import { Config } from "../config";
-import { GitHubClient, GitHubId, GitHubTeamId, InstalledClient, Org, OrgInvite, OrgRoles, Response } from "./gitHubTypes";
+import { AddMemberResponse, GitHubClient, GitHubId, GitHubTeamId, InstalledClient, Org, OrgInvite, OrgRoles, RemoveMemberResponse, Response } from "./gitHubTypes";
 import { AppConfig } from "./appConfig";
 import yaml from "js-yaml";
 import { throttling } from "@octokit/plugin-throttling";
@@ -230,15 +230,15 @@ class InstalledGitHubClient implements InstalledClient {
         this.orgName = orgName;
     }
 
-    async AddTeamsToCopilotSubscription(teamNames: string[]): Response<string[]> {   
+    async AddTeamsToCopilotSubscription(teamNames: string[]): Response<string[]> {
         // Such logic should not generally go in a facade, though the convenience
         // and lack of actual problems makes this violation of pattern more "okay."
-        if(teamNames.length < 1) {
+        if (teamNames.length < 1) {
             return {
                 // Should be "no op"
                 successful: true,
                 data: []
-            } 
+            }
         }
 
         try {
@@ -255,13 +255,13 @@ class InstalledGitHubClient implements InstalledClient {
                     successful: false
                 }
             }
-    
+
             return {
                 successful: true,
                 data: teamNames
             }
         }
-        catch(e) {
+        catch (e) {
             console.log(e);
             // TODO: actually catch exception and investigate...            
             return {
@@ -434,7 +434,7 @@ class InstalledGitHubClient implements InstalledClient {
         }
     }
 
-    public async AddTeamMember(team: GitHubTeamName, id: GitHubId): Response<unknown> {
+    public async AddTeamMember(team: GitHubTeamName, id: GitHubId): AddMemberResponse {
         const safeTeam = MakeTeamNameSafeAndApiFriendly(team);
 
         try {
@@ -446,13 +446,25 @@ class InstalledGitHubClient implements InstalledClient {
 
             return {
                 successful: true,
-                // TODO: make this type better to avoid nulls...
-                data: null
+                team: team,
+                user: id
             }
         }
-        catch {
+        catch (e) {
+            if (e instanceof Error) {
+                return {
+                    successful: false,
+                    team: team,
+                    user: id,
+                    message: e.message
+                }
+            }
+
             return {
-                successful: false
+                successful: false,
+                team: team,
+                user: id,
+                message: JSON.stringify(e)
             }
         }
     }
@@ -529,7 +541,7 @@ class InstalledGitHubClient implements InstalledClient {
         }
     }
 
-    public async RemoveTeamMemberAsync(team: GitHubTeamName, user: GitHubId): Response<unknown> {
+    public async RemoveTeamMemberAsync(team: GitHubTeamName, user: GitHubId): RemoveMemberResponse {
         const safeTeam = MakeTeamNameSafeAndApiFriendly(team);
 
         try {
@@ -541,13 +553,25 @@ class InstalledGitHubClient implements InstalledClient {
 
             return {
                 successful: true,
-                // TODO: make this type better to avoid nulls...
-                data: null
+                team: team,
+                user: user
             }
         }
-        catch {
+        catch (e) {
+            if (e instanceof Error) {
+                return {
+                    successful: false,
+                    team: team,
+                    user: user,
+                    message: e.message
+                }
+            }
+
             return {
-                successful: false
+                successful: false,
+                team: team,
+                user: user,
+                message: JSON.stringify(e)
             }
         }
     }

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -1,6 +1,6 @@
 import { CacheClient } from "../app";
 import { ILogger } from "../logging";
-import { GitHubTeamId, InstalledClient, OrgInvite, OrgRoles, Response } from "./gitHubTypes";
+import { AddMemberResponse, GitHubId, GitHubTeamId, InstalledClient, OrgInvite, OrgRoles, RemoveMemberResponse, Response } from "./gitHubTypes";
 import { OrgConfig } from "./orgConfig";
 
 export class GitHubClientCache implements InstalledClient {
@@ -81,7 +81,7 @@ export class GitHubClientCache implements InstalledClient {
         return this.client.GetAllTeams();
     }
 
-    AddTeamMember(team: string, id: string): Response<unknown> {
+    AddTeamMember(team: string, id: string): AddMemberResponse {
         return this.client.AddTeamMember(team, id);
     }
 
@@ -134,7 +134,7 @@ export class GitHubClientCache implements InstalledClient {
         return this.client.ListCurrentMembersOfGitHubTeam(team);
     }
 
-    RemoveTeamMemberAsync(team: string, user: string): Response<unknown> {
+    RemoveTeamMemberAsync(team: string, user: string): RemoveMemberResponse {
         return this.client.RemoveTeamMemberAsync(team, user);
     }
 

--- a/src/services/gitHubTypes.ts
+++ b/src/services/gitHubTypes.ts
@@ -25,11 +25,11 @@ export interface InstalledClient {
     AddOrgMember(id: GitHubId): Response
     IsUserMember(id: GitHubId): Response<boolean>
     GetAllTeams(): Response<GitHubTeamId[]>
-    AddTeamMember(team: GitHubTeamName, id: GitHubId): Response
+    AddTeamMember(team: GitHubTeamName, id: GitHubId): AddMemberResponse
     CreateTeam(teamName: GitHubTeamName, description:string): Response
     DoesUserExist(gitHubId: string): Response<GitHubId>
     ListCurrentMembersOfGitHubTeam(team: GitHubTeamName): Response<GitHubId[]>
-    RemoveTeamMemberAsync(team: GitHubTeamName, user: GitHubId): Response
+    RemoveTeamMemberAsync(team: GitHubTeamName, user: GitHubId): RemoveMemberResponse
     UpdateTeamDetails(team: GitHubTeamName, description: string): Response
     AddSecurityManagerTeam(team: GitHubTeamName): Promise<unknown>
     GetConfigurationForInstallation(): Response<OrgConfig>    
@@ -41,6 +41,37 @@ export interface InstalledClient {
     AddTeamsToCopilotSubscription(teamNames: GitHubTeamName[]):Response<string[]>
 }
 
+export type AddMemberResponse = Promise<AddMemberSucceeded | AddMemberFailed>
+
+export type AddMemberSucceeded = {
+    successful: true,
+    user: GitHubId,
+    team: GitHubTeamName
+}
+
+export type AddMemberFailed = {
+    successful: false,
+    user: GitHubId,
+    team: GitHubTeamName,
+    message: string
+}
+
+export type RemoveMemberResponse = Promise<RemoveMemberSucceeded | RemoveMemberFailed>
+
+export type RemoveMemberSucceeded = {
+    successful: true,
+    user: GitHubId,
+    team: GitHubTeamName
+}
+
+export type RemoveMemberFailed = {
+    successful: false,
+    user: GitHubId,
+    team: GitHubTeamName,
+    message: string
+}
+
+
 
 export type GenericSucceededResponse<T> = {
     successful: true,
@@ -48,7 +79,8 @@ export type GenericSucceededResponse<T> = {
 }
 
 export type FailedResponse = {
-    successful: false
+    successful: false,
+    message?:string
 }
 
 export type Response<T = unknown> = Promise<GenericSucceededResponse<T> | FailedResponse>;


### PR DESCRIPTION
As title says.

This doesn't solve issues with adding certain members to teams (which is typically outside the control of this bot), but it does help clarify problems faster by exposing the underlying issues with add/remove team member operations.