### PR TITLE
:bug: individually add copilot teams

### DIFF
--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -247,7 +247,7 @@ class InstalledGitHubClient implements InstalledClient {
             try {
                 const response = await this.gitHubClient.request("POST /orgs/{org}/copilot/billing/selected_teams", {
                     org: this.orgName,
-                    selected_teams: teamNames,
+                    selected_teams: [team],
                     headers: {
                         'X-GitHub-Api-Version': '2022-11-28'
                     }

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -256,7 +256,8 @@ class InstalledGitHubClient implements InstalledClient {
                 if (response.status < 200 || response.status > 299) {
                     responses.push({
                         successful: false,
-                        team: team
+                        team: team,
+                        message: response.status.toString()
                     });
                 }
 
@@ -266,11 +267,11 @@ class InstalledGitHubClient implements InstalledClient {
                 });
             }
             catch (e) {
-                console.log(e);
-                // TODO: actually catch exception and investigate...            
+                console.log(e);                                
                 responses.push({
                     successful: false,
-                    team: team
+                    team: team,
+                    message: JSON.stringify(e)
                 });
             }
         }

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -1,6 +1,6 @@
 import { CacheClient } from "../app";
 import { ILogger } from "../logging";
-import { AddMemberResponse, GitHubId, GitHubTeamId, InstalledClient, OrgInvite, OrgRoles, RemoveMemberResponse, Response } from "./gitHubTypes";
+import { AddMemberResponse, CopilotAddResponse, GitHubId, GitHubTeamId, InstalledClient, OrgInvite, OrgRoles, RemoveMemberResponse, Response } from "./gitHubTypes";
 import { OrgConfig } from "./orgConfig";
 
 export class GitHubClientCache implements InstalledClient {
@@ -13,7 +13,7 @@ export class GitHubClientCache implements InstalledClient {
         this.cacheClient = cacheClient;
         this.logger = logger;
     }
-    AddTeamsToCopilotSubscription(teamNames: string[]): Response<string[]> {
+    AddTeamsToCopilotSubscription(teamNames: string[]): Response<CopilotAddResponse[]> {
         return this.client.AddTeamsToCopilotSubscription(teamNames);
     }
     

--- a/src/services/gitHubTypes.ts
+++ b/src/services/gitHubTypes.ts
@@ -50,6 +50,7 @@ export type CopilotAddSucceeded = {
 
 export type CopilotAddFailed = {
     successful: false,
+    message: string,
     team: GitHubTeamName
 }
 

--- a/src/services/gitHubTypes.ts
+++ b/src/services/gitHubTypes.ts
@@ -38,7 +38,19 @@ export interface InstalledClient {
     GetPendingOrgInvites():Response<OrgInvite[]>
     CancelOrgInvite(invite:OrgInvite): Response    
     ListPendingInvitesForTeam(teamName: GitHubTeamName):Response<OrgInvite[]>
-    AddTeamsToCopilotSubscription(teamNames: GitHubTeamName[]):Response<string[]>
+    AddTeamsToCopilotSubscription(teamNames: GitHubTeamName[]):Response<CopilotAddResponse[]>
+}
+
+export type CopilotAddResponse = CopilotAddSucceeded | CopilotAddFailed
+
+export type CopilotAddSucceeded = {
+    successful: true,
+    team: GitHubTeamName
+}
+
+export type CopilotAddFailed = {
+    successful: false,
+    team: GitHubTeamName
 }
 
 export type AddMemberResponse = Promise<AddMemberSucceeded | AddMemberFailed>

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -2,7 +2,7 @@
 
 import { Log, LogError } from "../logging";
 import { AppConfig } from "./appConfig";
-import { FailedResponse, GitHubId, InstalledClient, OrgInvite } from "./gitHubTypes";
+import { CopilotAddResponse, FailedResponse, GitHubId, InstalledClient, OrgInvite } from "./gitHubTypes";
 import { IGitHubInvitations } from "./githubInvitations";
 import { SearchAllAsync } from "./ldapClient";
 import { OrgConfig } from "./orgConfig";
@@ -164,7 +164,7 @@ type ReturnTypeOfSyncOrg = {
     syncedSecurityManagerTeams: string[];
     orgOwnersGroup: string;
     ignoredTeams: string[];
-    copilotTeams: string[];
+    copilotTeams: CopilotAddResponse[];
 }
 
 type FailedSecSync = {
@@ -230,7 +230,7 @@ async function syncOrg(installedGitHubClient: InstalledClient, appConfig: AppCon
         syncedSecurityManagerTeams: [] as string[],
         orgOwnersGroup: "",
         ignoredTeams: [] as string[],
-        copilotTeams: [] as string[]
+        copilotTeams: [] as CopilotAddResponse[]
     }
 
     // TODO: add this back once these APIs make sense


### PR DESCRIPTION
* This prevents overflow issues due to large amounts of copilot teams while also allowing the overall call to succeed when one team in the batch is bad.
* This change is being made after new failures were found where 1 team with no members would cause the entire batch of additions to fail.