### PR TITLE
:bulb: use TeamsToIgnore to ignore member group

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,10 @@
             "internalConsoleOptions": "openOnSessionStart",
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
-            ]
+            ],
+            "env": {
+                "NODE_TLS_REJECT_UNAUTHORIZED": "0",
+            }
         }
     ]
 }

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -335,8 +335,9 @@ async function syncOrg(installedGitHubClient: InstalledClient, appConfig: AppCon
         await Promise.all(orgMembershipPromises);
     }
 
-    let currentMembers: GitHubId[] = [];
-    if (membersGroupName != undefined || membersGroupName != null) {
+    let currentMembers: GitHubId[] = [];    
+    // TODO: add log message to explain group being skipped if it is included in TeamsToIgnore
+    if (membersGroupName != undefined && membersGroupName != null && !appConfig.TeamsToIgnore.includes(membersGroupName)) {
         Log(`Syncing Members for ${installedGitHubClient.GetCurrentOrgName()}: ${membersGroupName}`)
         const currentMembersResponse = await SynchronizeOrgMembers(installedGitHubClient, membersGroupName, appConfig, orgConfig.DisplayNameToSourceMap)
 


### PR DESCRIPTION
* When applicable, this results in a more consistent experience AND resolves the problem where an Org may set OrgMembers to 'NA' instead of simply leaving it blank
* This also updates a debug time environment variable for VS Code so that **local** and **non production** debugging can be slightly easier...