### PR TITLE
:fast_forward: check membership as needed

### DIFF
--- a/src/handlers/syncSpecificTeamHandler.ts
+++ b/src/handlers/syncSpecificTeamHandler.ts
@@ -36,12 +36,6 @@ export async function syncSpecificTeamHandler(
 
     const invitationsClient = GetInvitationsClient(orgClient);
 
-    const existingOrgMembers = await orgClient.GetOrgMembers();
-
-    if(!existingOrgMembers.successful) {
-        return res.status(500).json("Unable to fetch org members");    
-    }
-
     const invitesResponse = await invitationsClient.ListInvites();
 
     if(!invitesResponse.successful) {
@@ -60,7 +54,7 @@ export async function syncSpecificTeamHandler(
 
     const sourceTeamMap = orgConfig.data.DisplayNameToSourceMap;
 
-    const response = await SyncTeam(teamName, orgClient, appConfig, existingOrgMembers.data, invites, sourceTeamMap);
+    const response = await SyncTeam(teamName, orgClient, appConfig, invites, sourceTeamMap);
 
     return res.status(200).json(response);
 }

--- a/src/services/gitHub.ts
+++ b/src/services/gitHub.ts
@@ -364,19 +364,6 @@ class InstalledGitHubClient implements InstalledClient {
         }
     }
 
-    public async GetOrgMembers(): Response<GitHubId[]> {
-        const response = await this.gitHubClient.paginate(this.gitHubClient.rest.orgs.listMembers, {
-            org: this.orgName
-        })
-
-        return {
-            successful: true,
-            data: response.map(i => {
-                return i.login
-            })
-        }
-    }
-
     public GetCurrentOrgName(): string {
         return this.orgName;
     }

--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -148,9 +148,5 @@ export class GitHubClientCache implements InstalledClient {
 
     GetConfigurationForInstallation(): Response<OrgConfig> {
         return this.client.GetConfigurationForInstallation();
-    }
-
-    GetOrgMembers(): Response<string[]> {
-        return this.client.GetOrgMembers();
-    }
+    }    
 }

--- a/src/services/gitHubTypes.ts
+++ b/src/services/gitHubTypes.ts
@@ -32,8 +32,7 @@ export interface InstalledClient {
     RemoveTeamMemberAsync(team: GitHubTeamName, user: GitHubId): RemoveMemberResponse
     UpdateTeamDetails(team: GitHubTeamName, description: string): Response
     AddSecurityManagerTeam(team: GitHubTeamName): Promise<unknown>
-    GetConfigurationForInstallation(): Response<OrgConfig>    
-    GetOrgMembers(): Response<GitHubId[]>
+    GetConfigurationForInstallation(): Response<OrgConfig>        
     SetOrgRole(id: GitHubId, role: OrgRoles): Response
     GetPendingOrgInvites():Response<OrgInvite[]>
     CancelOrgInvite(invite:OrgInvite): Response    


### PR DESCRIPTION
* General org membership checking is being removed and replaced by just in time checks to save on the amount of calls going to GitHub's API, which will help both general sync performance (as now there is no up-front need to fetch all members, which for large orgs is intense) as well as with issues where the sync bot was running into GitHub API rate limits (less calls == less chance of hitting the API rate limit)