### PR TITLE
Enhance GitHub results cache

### DIFF
--- a/src/services/gitHubCache.ts
+++ b/src/services/gitHubCache.ts
@@ -117,7 +117,8 @@ export class GitHubClientCache implements InstalledClient {
                 properties: {
                     "Data": gitHubId,
                     "Operation": "DoesUserExist",
-                    "Group": "GitHub"
+                    "Group": "GitHub",
+                    "Value": result
                 }
             })
 


### PR DESCRIPTION
* Includes enhancement to how false/true values are cached for membership checks. This should resolve pain around needing to wait for 2 days for a membership check to clear.
* Adds additional logging fields for cache hits to make triaging issues easier.

Future enhancements may include allowing the caching values to be set via App Configuration.