### PR TITLE
Add ability to handle users with periods in names

### DIFF
--- a/src/handlers/syncSpecificTeamHandler.ts
+++ b/src/handlers/syncSpecificTeamHandler.ts
@@ -29,6 +29,7 @@ export async function syncSpecificTeamHandler(
 ) {    
     const orgId = c.request.query.orgId! as unknown as number;
     const teamName = c.request.query.teamName! as unknown as string;
+    const dryRun = c.request.query.dryRun as unknown as boolean ?? true;
 
     const client = GetClient();
     const orgClient = await client.GetOrgClient(orgId);
@@ -54,7 +55,7 @@ export async function syncSpecificTeamHandler(
 
     const sourceTeamMap = orgConfig.data.DisplayNameToSourceMap;
 
-    const response = await SyncTeam(teamName, orgClient, appConfig, invites, sourceTeamMap);
+    const response = await SyncTeam(teamName, orgClient, appConfig, invites, sourceTeamMap, dryRun);
 
     return res.status(200).json(response);
 }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -85,6 +85,13 @@ paths:
           schema:
             type: string                          
           required: true
+        - in: query
+          name: dryRun
+          description: Whether to run the sync, or simply return what actions will be taken. Defaults to True (i.e., perform as Dry Run).
+          schema:
+            type: boolean
+            default: true
+          required: false          
       responses:
         "200":
           description: A successful response

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -50,9 +50,9 @@ async function GetGitHubIds(teamName: string, config: AppConfig): Promise<GitHub
     return {
         Succeeded: true,
         Ids: membersFromSourceOfTruth.entries.map(e => {
-            // const replace1 = replaceAll(e.cn, '_', '-');
-            // const replace2 = replaceAll(replace1, ".", "-")
-            return replaceAll(e.cn, '_', '-') + config.GitHubIdAppend;
+            const replace1 = replaceAll(e.cn, '_', '-');
+            const replace2 = replace1.replaceAll(".", "-");
+            return replace2 + config.GitHubIdAppend;
         })
     }
 }

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -50,6 +50,8 @@ async function GetGitHubIds(teamName: string, config: AppConfig): Promise<GitHub
     return {
         Succeeded: true,
         Ids: membersFromSourceOfTruth.entries.map(e => {
+            // const replace1 = replaceAll(e.cn, '_', '-');
+            // const replace2 = replaceAll(replace1, ".", "-")
             return replaceAll(e.cn, '_', '-') + config.GitHubIdAppend;
         })
     }
@@ -108,7 +110,7 @@ async function SynchronizeOrgMembers(installedGitHubClient: InstalledClient, tea
     };
 }
 
-async function SynchronizeGitHubTeam(installedGitHubClient: InstalledClient, teamName: string, config: AppConfig, existingInvites: OrgInvite[], sourceTeamMap: Map<string, string>, checkOrgMembers: boolean = true) {
+async function SynchronizeGitHubTeam(installedGitHubClient: InstalledClient, teamName: string, config: AppConfig, existingInvites: OrgInvite[], sourceTeamMap: Map<string, string>, checkOrgMembers: boolean = true, dryRun: boolean = false) {
     function GetSourceOrReturn(teamName: string) {
         return sourceTeamMap.get(teamName) ?? teamName;
     }
@@ -169,6 +171,10 @@ async function SynchronizeGitHubTeam(installedGitHubClient: InstalledClient, tea
     }
 
     Log(JSON.stringify(teamSyncNotes));
+
+    if(dryRun) {
+        return teamSyncNotes;
+    }
 
     const deleteResponses = await Promise.all(teamMembersToRemove.map(mtr => installedGitHubClient.RemoveTeamMemberAsync(teamName, mtr)));
     const addResponses = await Promise.all(teamMembersToAdd.map(mta => installedGitHubClient.AddTeamMember(teamName, mta)));
@@ -473,8 +479,8 @@ async function syncOrg(installedGitHubClient: InstalledClient, appConfig: AppCon
 }
 
 
-export async function SyncTeam(teamName: string, client: InstalledClient, config: AppConfig, invites: OrgInvite[], sourceTeamMap: Map<string, string>) {
-    const response = await SynchronizeGitHubTeam(client, teamName, config, invites, sourceTeamMap, true);
+export async function SyncTeam(teamName: string, client: InstalledClient, config: AppConfig, invites: OrgInvite[], sourceTeamMap: Map<string, string>, dryRun: boolean = false) {
+    const response = await SynchronizeGitHubTeam(client, teamName, config, invites, sourceTeamMap, true, dryRun);
 
     return response;
 }

--- a/src/services/githubSync.ts
+++ b/src/services/githubSync.ts
@@ -172,7 +172,7 @@ async function SynchronizeGitHubTeam(installedGitHubClient: InstalledClient, tea
 
     Log(JSON.stringify(teamSyncNotes));
 
-    if(dryRun) {
+    if(dryRun === true) {
         return teamSyncNotes;
     }
 


### PR DESCRIPTION
This also adds the ability to dry run a team specific sync when calling the endpoints directly.